### PR TITLE
Job: #8605 Dispatch display events in welcome.  A previous change

### DIFF
--- a/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTest.java
+++ b/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTest.java
@@ -30,6 +30,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xtuml.bp.core.ExternalEntity_c;
@@ -68,6 +69,11 @@ public class WelcomePageTest extends TestCase {
 		super();
 	}
 
+	@Override
+	public void setUp() {
+		while(PlatformUI.getWorkbench().getDisplay().readAndDispatch());
+	}
+	
 //	// enforce ordering of tests in this class
 //	@Test
 //	public void testWelcomePageMicrowaveProject() throws CoreException, Exception {

--- a/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTestGPS.java
+++ b/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTestGPS.java
@@ -91,6 +91,11 @@ public class WelcomePageTestGPS extends TestCase {
             markingFolder + "domain.mark"
             };
 
+	@Override
+	public void setUp() {
+		while(PlatformUI.getWorkbench().getDisplay().readAndDispatch());
+	}
+	
 	public WelcomePageTestGPS() {
 		super();
 	}

--- a/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTestMetamodel.java
+++ b/src/org.xtuml.bp.welcome.test/src/org/xtuml/bp/welcome/test/WelcomePageTestMetamodel.java
@@ -69,7 +69,11 @@ public class WelcomePageTestMetamodel extends TestCase {
 
 	private String[] expectedFiles = expectedXtUMLFiles;
 
-
+	@Override
+	public void setUp() {
+		while(PlatformUI.getWorkbench().getDisplay().readAndDispatch());
+	}
+	
 	public WelcomePageTestMetamodel() {
 		super();
 	}


### PR DESCRIPTION
removed this from BaseTest.  Welcome tests freeze otherwise.