### PR TITLE
job:#10010 REmoved the antrl.ui dependency, we can't use it anymore

### DIFF
--- a/releng/org.xtuml.bp.releng.parent.tests/pom.xml
+++ b/releng/org.xtuml.bp.releng.parent.tests/pom.xml
@@ -106,11 +106,6 @@
 							</requirement>
 							<requirement>
 								<type>eclipse-feature</type>
-								<id>org.antlr.ui</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-							<requirement>
-								<type>eclipse-feature</type>
 								<id>org.eclipse.xtext.sdk</id>
 								<versionRange>0.0.0</versionRange>
 							</requirement>


### PR DESCRIPTION
because the old antrl version we use requires the compatibility layer
which was removed in Eclipse Neon.