### PR TITLE
job #10232 - when building on the server, maven throws and error if

### DIFF
--- a/src/org.xtuml.bp.debug.ui.test/src/VerifierTestFull.java
+++ b/src/org.xtuml.bp.debug.ui.test/src/VerifierTestFull.java
@@ -1,5 +1,6 @@
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.xtuml.bp.debug.test.GlobalTestSetupClass;
 
 import junit.framework.TestSuite;
 
@@ -9,6 +10,7 @@ import junit.framework.TestSuite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ 
+	GlobalTestSetupClass.class, // This is only here because the following two are temporarily disabled and maven doesn't like if there are no tests to execute
 	/* Disabling due to server hangs
 	VerifierTestSuite.class, 
 	VerifierTestSuite2.class, */


### PR DESCRIPTION
there are no tests to execute.  So this change works around that by
running a setup "test".