### PR TITLE
Remove obsolete argument on invocation of ProjectUtilities.importExistingProject

### DIFF
--- a/src/org.xtuml.bp.io.mdl.test/src/org/xtuml/bp/io/mdl/test/ImportExistingTests.java
+++ b/src/org.xtuml.bp.io.mdl.test/src/org/xtuml/bp/io/mdl/test/ImportExistingTests.java
@@ -40,7 +40,7 @@ public class ImportExistingTests extends TestCase {
     public void testProjectCreationNoImportIntoworkspace() throws Exception {
         
         String repository_location = BaseTest.getTestModelRespositoryLocation() + "/../";
-        ProjectUtilities.importExistingProject( repository_location + PROJECT_PATH, false );  // Do not copy into workspace
+        ProjectUtilities.importExistingProject( repository_location + PROJECT_PATH );
         BaseTest.dispatchEvents();
 
         ProjectUtilities.openxtUMLPerspective();


### PR DESCRIPTION
The resolution of #12073 eliminated the second parameter on importExistingProject.